### PR TITLE
Using latest JNativehook release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,11 @@ repositories {
         dirs 'libs'
     }
     mavenCentral()
-    maven {
-        url "https://oss.sonatype.org/service/local/repositories/snapshots/content/"
-    }
     mavenLocal()
 }
 
 dependencies {
-    compile 'com.github.kwhat:jnativehook:2.2-SNAPSHOT'// snap due to https://github.com/kwhat/jnativehook/issues/170 still open as of 2021-02-28
+    compile 'com.github.kwhat:jnativehook:2.2.1'
     compile 'com.ibm.icu:icu4j:68.2'
     compile 'org.slf4j:slf4j-api:1.7.29'
     compile 'org.slf4j:slf4j-simple:1.7.29'
@@ -49,7 +46,7 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    jar.archiveName = 'chocoratage.jar'
+    jar.archiveFileName = 'chocoratage.jar'
 }
 
 task copyLangSelImg(type: Copy) {

--- a/src/main/java/fr/raluy/chocoratage/KeyLogger.java
+++ b/src/main/java/fr/raluy/chocoratage/KeyLogger.java
@@ -19,7 +19,6 @@ public class KeyLogger implements NativeKeyListener {
     public KeyLogger() {
         try {
             GlobalScreen.registerNativeHook();
-            //GlobalScreen.setEventDispatcher(new DefaultDispatchService()); // https://github.com/kwhat/jnativehook/issues/277
             GlobalScreen.addNativeKeyListener(this);
         } catch (NativeHookException e) {
             String errMsg = "Impossible to register listening hook";


### PR DESCRIPTION
dependency to Jnativehook 2.2.1
New namespace com.github.kwhat.jnativehook
Removed workaround for https://github.com/kwhat/jnativehook/issues/277